### PR TITLE
feat: improve user experience

### DIFF
--- a/app/web/layouts/header/header.tsx
+++ b/app/web/layouts/header/header.tsx
@@ -1,8 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { AppstoreOutlined, CloudOutlined, DesktopOutlined, TagOutlined, SettingOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 import { Layout, Menu } from 'antd';
+import { SyncOutlined } from '@ant-design/icons';
 import { Link } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import * as actions from '@/store/actions';
 import logo from '@/asset/images/logo.png';
 import config from '../../../../env.json';
 import './style.scss';
@@ -39,9 +42,10 @@ const navMenuList: any = [{
 }]
 const HeaderComponent = (props: any) => {
     const { location } = props;
-    const { localIp } = useSelector((state: any) => state.global);
+    const { localIp = '127.0.0.1' } = useSelector((state: any) => state.global);
     const { pathname } = location;
     const [selectedKeys, setSelectedKeys] = useState([pathname]);
+    const { changeLocalIp } = bindActionCreators(actions, useDispatch());
     const handleSelectedKeys = (e: any) => {
         setSelectedKeys(e.key);
     }
@@ -80,6 +84,9 @@ const HeaderComponent = (props: any) => {
                         <QuestionCircleOutlined className="help-link" />
                     </a>
                     <span className="local-ip ml-20">{`本机IP: ${localIp}`}</span>
+
+                    {/* 主动更新本地IP */}
+                    <SyncOutlined className='refresh-cion' onClick={changeLocalIp} />
                 </div>
             </div>
         </Header>

--- a/app/web/layouts/header/style.scss
+++ b/app/web/layouts/header/style.scss
@@ -16,4 +16,9 @@
         vertical-align: sub;
         cursor: pointer;
     }
+    .refresh-cion {
+        color: #fff;
+        font-size: 16px;
+        margin-left: 10px;
+    }
 }

--- a/app/web/pages/proxyServer/index.tsx
+++ b/app/web/pages/proxyServer/index.tsx
@@ -408,7 +408,7 @@ class ProxyServer extends React.PureComponent<any, any> {
             width: 100,
             render: (value: any, row: any, index: any) => index + 1
         }, {
-            title: 'IP',
+            title: '用户IP',
             key: 'ip',
             dataIndex: 'ip',
             width: '15%',


### PR DESCRIPTION
###  简介
- 细节优化

### 变更
- 用户可以自行点击右上角刷新按钮更新本地 ip，不用再刷新整个页面。
- 代理服务的规则中，IP 字段改为 用户IP，便于理解

![image](https://user-images.githubusercontent.com/34759874/149608309-a7829384-d1e0-4ec6-aee1-139e5af1841b.png)
