### PR TITLE
feat: add ProxyServer url projectId #39

### DIFF
--- a/app/controller/proxy.js
+++ b/app/controller/proxy.js
@@ -3,16 +3,19 @@ const _ = require('lodash');
 class ProxyServerController extends Controller{
     //获取服务列表
     async list() {
-        const { pageSize, pageNo, search } = this.ctx.request.body;
+        const { pageSize, pageNo, search, projectId } = this.ctx.request.body;
+        let whereParams = {
+            '$or': [
+                { name: { '$like': `%${search}%` } },
+                { proxy_server_address: { '$like': `%${search}%` } }
+            ]
+        }
+        if (projectId) {
+            whereParams.id = projectId
+        }
         const result = await this.app.model.ProxyServer.findAndCountAll({
             attributes: ['id', 'name', 'proxy_server_address', 'api_doc_url', 'status', 'target', 'created_at', 'updated_at'],
-            where: {
-                '$or': [
-                    { name: { '$like': `%${search}%` } },
-                    { proxy_server_address: { '$like': `%${search}%` } }
-                ]
-                
-            },
+            where: whereParams,
             limit: pageSize,
             order: [['updated_at', 'DESC']],
             offset: (pageNo - 1) * pageSize


### PR DESCRIPTION
### 提交的变更类型是
- [x] 添加新功能
- [ ] 修复 bug
- [ ] 优化代码风格
- [ ] 代码重构
- [ ] 增加单元测试
- [ ] 增加依赖库/工具

### 相关链接
#39 
### 需求描述和解决方案
#### 描述
url 携带项目 id，代理列表页需要接收并展开对应的项目
#### 解决方案
1、增加url携带项目id逻辑

2、更改保存的常用项目的数据结构，用id进行唯一标识

3、优化部分逻辑，去除部分`selectedTag `参数

支持通过`/page/proxy-server?projectId=74`跳转代理服务具体项目
### 自查清单
- [ ] 代码遵循这个项目的风格指南
- [ ] 对代码进行了自我审查
- [ ] 已经在难以理解的代码处做了相关注释
- [ ] 更改不会产生新的警告
- [ ] 任何依赖更改都已合并并发布在下游模块中
