### PR TITLE
feat: collect use Object and max is 6

### DIFF
--- a/app/controller/proxy.js
+++ b/app/controller/proxy.js
@@ -3,16 +3,19 @@ const _ = require('lodash');
 class ProxyServerController extends Controller{
     //获取服务列表
     async list() {
-        const { pageSize, pageNo, search } = this.ctx.request.body;
+        const { pageSize, pageNo, search, projectId } = this.ctx.request.body;
+        let where = {
+            '$or': [
+                { name: { '$like': `%${search}%` } },
+                { proxy_server_address: { '$like': `%${search}%` } }
+            ]
+        }
+        if (projectId) {
+            where.id = projectId
+        }
         const result = await this.app.model.ProxyServer.findAndCountAll({
             attributes: ['id', 'name', 'proxy_server_address', 'api_doc_url', 'status', 'target', 'created_at', 'updated_at'],
-            where: {
-                '$or': [
-                    { name: { '$like': `%${search}%` } },
-                    { proxy_server_address: { '$like': `%${search}%` } }
-                ]
-                
-            },
+            where,
             limit: pageSize,
             order: [['updated_at', 'DESC']],
             offset: (pageNo - 1) * pageSize
@@ -27,7 +30,7 @@ class ProxyServerController extends Controller{
         const { id } = result;
         // 存储目标地址信息
         await this.ctx.service.proxyServerAddrs.create(targetAddrs, id);
-        this.ctx.body = this.app.utils.response(true, null); 
+        this.ctx.body = this.app.utils.response(true, null);
     }
 
     // 获取目标服务地址列表

--- a/app/web/pages/proxyServer/style.scss
+++ b/app/web/pages/proxyServer/style.scss
@@ -4,9 +4,21 @@
     justify-content: space-between;
     align-self: center;
     margin-bottom: 12px;
-    .search {
-      width: 260px;
-      height: 32px;
+    .title-left {
+      display: flex;
+      align-items: center;
+      .search {
+        width: 260px;
+        height: 32px;
+      }
+      .ant-tag {
+        .collect-tag-name {
+          max-width: 120px;
+          overflow: hidden; // 超出的文本隐藏
+          white-space: nowrap;
+          text-overflow: ellipsis; // 溢出用省略号显示
+        }
+      }
     }
   }
   .ant-tag-checkable {


### PR DESCRIPTION
### 提交的变更类型是
- [x] 添加新功能
- [ ] 修复 bug
- [ ] 优化代码风格
- [ ] 代码重构
- [ ] 增加单元测试
- [ ] 增加依赖库/工具

### 相关链接

### 需求描述和解决方案
#### 描述
1. #40 
- 收藏的项目用对象进行存储  
- 最多收藏6个项目  

2. #39 
- url 携带项目 id，代理列表页需要接收并展开对应的项目
- 支持通过 `/page/proxy-server?projectId=74` 跳转代理服务具体项目

#### 解决方案

### 自查清单
- [ ] 代码遵循这个项目的风格指南
- [ ] 对代码进行了自我审查
- [ ] 已经在难以理解的代码处做了相关注释
- [ ] 更改不会产生新的警告
- [ ] 任何依赖更改都已合并并发布在下游模块中
