### PR TITLE
feat: add target address valid

### DIFF
--- a/app/web/pages/proxyServer/components/proxyRuleModal/index.tsx
+++ b/app/web/pages/proxyServer/components/proxyRuleModal/index.tsx
@@ -56,6 +56,12 @@ class ProxyRuleModal extends React.PureComponent<any, any>{
             target: undefined
         })
     }
+    addressValidator = (rules: any, value: any, callback: any) => {
+        if (value?.includes('doraemon')) {
+            return callback('请使用 portalfront 地址，请勿使用 portalfront-doraemon 地址');
+        }
+        return callback();
+    }
     render() {
         const { visible, editable, proxyServer, confirmLoading, targetAddrs, localIp } = this.props;
         const { ip, target, remark, mode } = proxyServer;
@@ -114,7 +120,11 @@ class ProxyRuleModal extends React.PureComponent<any, any>{
                                     <Form.Item
                                         label="目标服务地址"
                                         name="target"
-                                        rules={[{ required: true, pattern: urlReg, message: '请输入正确格式的目标服务地址，以 http(s):// 开头' }]}
+                                        validateFirst
+                                        rules={[
+                                            { required: true, pattern: urlReg, message: '请输入正确格式的目标服务地址，以 http(s):// 开头' },
+                                            { validator: this.addressValidator }
+                                        ]}
                                     >
                                         <Input placeholder="请输入正确格式的目标服务地址，以 http(s):// 开头" />
                                     </Form.Item>


### PR DESCRIPTION
### 提交的变更类型是
- [x] 添加新功能
- [ ] 修复 bug
- [ ] 优化代码风格
- [ ] 代码重构
- [ ] 增加单元测试
- [ ] 增加依赖库/工具

### 相关链接

### 需求描述和解决方案
#### 描述
增加目标地址校验规则，和目标服务地址列表校验保持一致，不能填写portalfront-doraemon 地址
#### 解决方案

### 自查清单
- [ ] 代码遵循这个项目的风格指南
- [ ] 对代码进行了自我审查
- [ ] 已经在难以理解的代码处做了相关注释
- [ ] 更改不会产生新的警告
- [ ] 任何依赖更改都已合并并发布在下游模块中
