### PR TITLE
feat: send custom message to dingtalk rebot

### DIFF
--- a/app/controller/articleSubscription.js
+++ b/app/controller/articleSubscription.js
@@ -24,16 +24,15 @@ class ArticleSubscriptionController extends Controller {
     // 新增
     async createSubscription() {
         const { app, ctx } = this;
-        const { groupName, webHook, remark, topicIds, siteNames, sendType, sendCron, time, status } = ctx.request.body;
+        const { groupName, webHook, remark, topicIds = [], siteNames, sendType, sendCron, time, status, messageTitle, message, isAtAll } = ctx.request.body;
         if (_.isNil(groupName)) throw new Error('缺少必要参数 groupName');
         if (_.isNil(webHook)) throw new Error('缺少必要参数 webHook');
-        if (_.isNil(topicIds)) throw new Error('缺少必要参数 topicIds');
         if (_.isNil(siteNames)) throw new Error('缺少必要参数 siteNames');
         if (_.isNil(sendType)) throw new Error('缺少必要参数 sendType');
         if (_.isNil(sendCron)) throw new Error('缺少必要参数 sendCron');
         if (_.isNil(time)) throw new Error('缺少必要参数 time');
         // 数据库插入数据
-        const data = await ctx.service.articleSubscription.createSubscription({ groupName, webHook, remark, topicIds: topicIds.join(','), siteNames, sendType, sendCron, time, status });
+        const data = await ctx.service.articleSubscription.createSubscription({ groupName, webHook, remark, topicIds: topicIds?.join(','), siteNames, sendType, sendCron, time, status, messageTitle, message, isAtAll });
         const { id } = data
         if (_.isNil(id)) throw new Error('创建失败');
         // 向 agent 进程发消息
@@ -44,15 +43,14 @@ class ArticleSubscriptionController extends Controller {
     // 更新
     async updateSubscription() {
         const { ctx, app } = this;
-        const { id, groupName, webHook, remark, topicIds, siteNames, sendType, sendCron, time, status } = ctx.request.body;
+        const { id, groupName, webHook, remark, topicIds = [], siteNames, sendType, sendCron, time, status, messageTitle, message, isAtAll } = ctx.request.body;
         if (_.isNil(id)) throw new Error('缺少必要参数 id');
         if (_.isNil(groupName)) throw new Error('缺少必要参数 groupName');
         if (_.isNil(webHook)) throw new Error('缺少必要参数 webHook');
-        if (_.isNil(topicIds)) throw new Error('缺少必要参数 topicIds');
         if (_.isNil(siteNames)) throw new Error('缺少必要参数 siteNames');
         if (_.isNil(sendType)) throw new Error('缺少必要参数 sendType');
         if (_.isNil(sendCron)) throw new Error('缺少必要参数 sendCron');
-        await ctx.service.articleSubscription.updateSubscription(id, { groupName, webHook, remark, topicIds: topicIds.join(','), siteNames, sendType, sendCron, time, status, updated_at: new Date() })
+        await ctx.service.articleSubscription.updateSubscription(id, { groupName, webHook, remark, topicIds: topicIds?.join(','), siteNames, sendType, sendCron, time, status, messageTitle, message, isAtAll, updated_at: new Date() })
         // 向 agent 进程发消息
         app.messenger.sendToAgent(status === 1 ? 'changeTimedTask' : 'cancelTimedTask', { id, sendCron })
         ctx.body = app.utils.response(true, id);

--- a/app/model/article_subscription.js
+++ b/app/model/article_subscription.js
@@ -13,7 +13,10 @@ module.exports = app => {
         status: { type: INTEGER(2), defaultValue: 1 },
         is_delete: { type: INTEGER(2), defaultValue: 0 },
         created_at: DATE,
-        updated_at: DATE
+        updated_at: DATE,
+        messageTitle: STRING(64),
+        message: STRING(2000),
+        isAtAll: { type: INTEGER(2), defaultValue: 0 }
     },{
         freezeTableName: true
     });

--- a/app/utils/articleSubscription.js
+++ b/app/utils/articleSubscription.js
@@ -102,7 +102,7 @@ const getJueJinHot = async (id, groupName, siteName, topicName, topicUrl, webHoo
 // 自定义消息
 const customMessage = async (id, groupName, siteName, messageTitle, message, isAtAll, webHook, app) => {
     try {
-        sendArticleMsg(messageTitle, message, webHook, { isAtAll })
+        sendArticleMsg(messageTitle, message?.replace(/\\n/g, '\n')?.replace(/\\r/g, '\r'), webHook, { isAtAll })
         logFunc(app, id, groupName, siteName, messageTitle, '成功')
     } catch (err) {
         logFunc(app, id, groupName, siteName, messageTitle, `失败`, `${ JSON.stringify(err) }`)

--- a/app/utils/articleSubscription.js
+++ b/app/utils/articleSubscription.js
@@ -99,6 +99,16 @@ const getJueJinHot = async (id, groupName, siteName, topicName, topicUrl, webHoo
     }
 }
 
+// 自定义消息
+const customMessage = async (id, groupName, siteName, messageTitle, message, isAtAll, webHook, app) => {
+    try {
+        sendArticleMsg(messageTitle, message, webHook, { isAtAll })
+        logFunc(app, id, groupName, siteName, messageTitle, '成功')
+    } catch (err) {
+        logFunc(app, id, groupName, siteName, messageTitle, `失败`, `${ JSON.stringify(err) }`)
+    }
+}
+
 // 打印文章订阅任务结果
 const logFunc = (app, id, groupName, siteName, topicName, msg, errMsg = '') => {
     if (!articleResultWebhook) return
@@ -118,5 +128,6 @@ module.exports = {
     getGithubTrendingFromGithub,
     getGithubTrendingFromJueJin,
     getGithubTrendingFromServerless,
-    getJueJinHot
+    getJueJinHot,
+    customMessage
 }

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -57,10 +57,10 @@ const sendHostsUpdateMsg = async (webhook_url, basicInfo, ip, address, operation
 }
 
 // 发送文章订阅消息
-const sendArticleMsg = async (title, text, webhook) => {
+const sendArticleMsg = async (title, text, webhook, at = {}) => {
     const feChatRobot = new ChatBot({ webhook })
     feChatRobot
-        .markdown(title, text)
+        .markdown(title, text, at)
         .catch(ex => console.error(ex))
 }
 

--- a/app/web/pages/articleSubscription/components/ChooseSendTime/index.tsx
+++ b/app/web/pages/articleSubscription/components/ChooseSendTime/index.tsx
@@ -50,6 +50,7 @@ class ChooseSendTime extends React.Component<IProps, IState> {
         return (
             <div className="send-time">
                 <Select style={{ width: 120 }} value={sendType} onChange={(val) => { this.handleChange('sendType', val) }}>
+                    <Option value={SUBSCRIPTIONSENDTYPE.FRIDAY}>{SUBSCRIPTIONSENDTYPECN[SUBSCRIPTIONSENDTYPE.FRIDAY]}</Option>
                     <Option value={SUBSCRIPTIONSENDTYPE.WORKDAY}>{SUBSCRIPTIONSENDTYPECN[SUBSCRIPTIONSENDTYPE.WORKDAY]}</Option>
                     <Option value={SUBSCRIPTIONSENDTYPE.EVERYDAY}>{SUBSCRIPTIONSENDTYPECN[SUBSCRIPTIONSENDTYPE.EVERYDAY]}</Option>
                 </Select>

--- a/app/web/pages/articleSubscription/consts/index.ts
+++ b/app/web/pages/articleSubscription/consts/index.ts
@@ -6,12 +6,14 @@ export enum SUBSCRIPTIONSTATUS {
 
 // 订阅的推送时间方式 1 周一至周五 2 每天
 export enum SUBSCRIPTIONSENDTYPE {
+    FRIDAY = 0,
     WORKDAY = 1,
     EVERYDAY = 2
 }
 
 // 订阅的推送时间方式 1 周一至周五 2 每天
 export const SUBSCRIPTIONSENDTYPECN = {
+    [SUBSCRIPTIONSENDTYPE.FRIDAY]: '每周五',
     [SUBSCRIPTIONSENDTYPE.WORKDAY]: '周一至周五',
     [SUBSCRIPTIONSENDTYPE.EVERYDAY]: '每天'
 }

--- a/app/web/pages/articleSubscription/index.tsx
+++ b/app/web/pages/articleSubscription/index.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment, useEffect, useState } from 'react';
 import { PlusCircleOutlined } from '@ant-design/icons';
 import SubscriptionModal from './components/SubscriptionModal';
-import { Divider, Table, Button, Breadcrumb, Input, Modal, Switch, message as Message } from 'antd';
+import { Divider, Table, Button, Breadcrumb, Input, Modal, Switch, message as Message, message } from 'antd';
 import { SUBSCRIPTIONSENDTYPECN, SUBSCRIPTIONSTATUS } from './consts';
 import { API } from '@/api';
 import helpIcon from '../../asset/images/help-icon.png';
@@ -49,6 +49,14 @@ const ArticleSubscriptionList = (props: any) => {
                 title: '钉钉群名称',
                 dataIndex: 'groupName',
                 key: 'groupName'
+            },
+            {
+                title: '订阅类型',
+                dataIndex: 'siteNames',
+                key: 'siteNames',
+                render: (siteNames, record) => {
+                    return siteNames === '自定义消息' && !!message ? '自定义消息' : ' 文章订阅';
+                }
             },
             {
                 title: '订阅项',

--- a/app/web/pages/articleSubscription/index.tsx
+++ b/app/web/pages/articleSubscription/index.tsx
@@ -55,13 +55,16 @@ const ArticleSubscriptionList = (props: any) => {
                 dataIndex: 'siteNames',
                 key: 'siteNames',
                 render: (siteNames, record) => {
-                    return siteNames === '自定义消息' && !!message ? '自定义消息' : ' 文章订阅';
+                    return siteNames === '自定义消息' && !!record?.message ? '自定义消息' : '文章订阅';
                 }
             },
             {
                 title: '订阅项',
                 dataIndex: 'siteNames',
-                key: 'siteNames'
+                key: 'siteNames',
+                render: (siteNames, record) => {
+                    return siteNames === '自定义消息' && !!record?.message ? record?.messageTitle : siteNames;
+                }
             },
             {
                 title: '备注',


### PR DESCRIPTION
### 提交的变更类型是
- [x] 添加新功能
- [ ] 修复 bug
- [ ] 优化代码风格
- [ ] 代码重构
- [ ] 增加单元测试
- [ ] 增加依赖库/工具

### 相关链接
![image](https://github.com/DTStack/doraemon/assets/34759874/e32420a0-5ccb-41b6-bb5d-6542239e7dab)
<img width="439" alt="image" src="https://github.com/DTStack/doraemon/assets/34759874/e37ef8bc-21b8-4588-954e-933c64d9a0f2">


### 需求描述和解决方案
#### 描述
1、文章订阅页面支持自定义消息，可以发送到钉钉机器人

#### 解决方案

### 自查清单
- [ ] 代码遵循这个项目的风格指南
- [ ] 对代码进行了自我审查
- [ ] 已经在难以理解的代码处做了相关注释
- [ ] 更改不会产生新的警告
- [ ] 任何依赖更改都已合并并发布在下游模块中
