### PR TITLE
feat: show chrome tool

### DIFF
--- a/app/web/layouts/basicLayout/index.tsx
+++ b/app/web/layouts/basicLayout/index.tsx
@@ -1,14 +1,35 @@
 import * as React from 'react';
-import {Layout } from 'antd';
+import { Layout, Modal } from 'antd';
 import classnames from 'classnames';
 import { renderRoutes } from 'react-router-config'
 import './style.scss';
 import Header from '../header/header';
+import { ChromeOutlined } from '@ant-design/icons';
 const { Content} = Layout;
 
 const BasicLayout = (props: any)=>{
-    const {className,route,location} = props;
+    const {className, route, location} = props;
     const { pathname } = location;
+
+    // 如果弹出过哆啦A梦 Chrome 插件的弹框，则后续不再弹出
+    React.useEffect(() => {
+        const key = 'show_chrome_tool'
+        const hasBeenShowed = localStorage.getItem(key) === 'yes'
+        const chromeToolUrl = 'https://github.com/JackWang032/doraemon-proxy-tool'
+
+        !hasBeenShowed && Modal.info({
+            title: '哆啦A梦 Chrome 插件',
+            icon: <ChromeOutlined />,
+            content: <>
+                <p>支持代理服务的快速切换环境、数栈自动登录等功能，请点击下方链接了解详情：</p>
+                <a href={chromeToolUrl} target='_blank'>{chromeToolUrl}</a>
+            </>,
+            onOk() {
+                localStorage.setItem(key, 'yes')
+            }
+        });
+    }, [pathname])
+
     return (
         <Layout className="layout-basic">
             <Header location={location}/>


### PR DESCRIPTION
### 提交的变更类型是
- [x] 添加新功能
- [ ] 修复 bug
- [ ] 优化代码风格
- [ ] 代码重构
- [ ] 增加单元测试
- [ ] 增加依赖库/工具

### 相关链接

### 需求描述和解决方案
#### 描述

主动展示哆啦A梦 Chrome 插件，点击“知道了”后续不再展示， 数据存在了 localStorage

<img width="1220" alt="image" src="https://github.com/user-attachments/assets/26fdc07b-c677-4624-baf2-993f31d5d5a1">


#### 解决方案

### 自查清单
- [ ] 代码遵循这个项目的风格指南
- [ ] 对代码进行了自我审查
- [ ] 已经在难以理解的代码处做了相关注释
- [ ] 更改不会产生新的警告
- [ ] 任何依赖更改都已合并并发布在下游模块中
