### PR TITLE
fix: fix logo upload handling

### DIFF
--- a/app/controller/appCenters.js
+++ b/app/controller/appCenters.js
@@ -3,10 +3,6 @@ const _ = require('lodash');
 const moment = require('moment');
 const path = require('path');
 const fs = require('fs');
-// 异步二进制 写入流
-const awaitWriteStream = require('await-stream-ready').write;
-// 管道读入一个虫洞。
-const sendToWormhole = require('stream-wormhole');
 
 class AppCentersController extends Controller {
     async getAppCenterList() {
@@ -126,10 +122,17 @@ class AppCentersController extends Controller {
     async uploadLogo() {
         const { app, ctx } = this;
         const id = ctx.params.id;
-        // 读取文件流
-        const stream = await this.ctx.getFileStream();
-        // 文件名
-        const fileName = stream.filename;
+        const files = ctx.request.files
+            ? Array.isArray(ctx.request.files)
+                ? ctx.request.files
+                : [ctx.request.files]
+            : [];
+        const file = files[0];
+        if (!file) {
+            ctx.throw(400, '缺少上传文件');
+        }
+        // 全局 multipart 已经是 file 模式，这里直接复用临时文件，避免重复消费请求体
+        const fileName = file.filename;
         // 目标文件夹，没有就创建，创建多级目录存储
         const date = new Date();
         const dirTree = [
@@ -142,14 +145,14 @@ class AppCentersController extends Controller {
         const dir = app.utils.createFolder(dirTree);
         // 创建文件
         const target = path.join(dir, fileName);
-        const writeStream = fs.createWriteStream(target);
         try {
-            // 异步把文件流 写入
-            await awaitWriteStream(stream.pipe(writeStream));
+            fs.copyFileSync(file.filepath, target);
         } catch (err) {
-            // 如果出现错误，关闭管道
-            await sendToWormhole(stream);
             throw new Error('图片上传出错');
+        } finally {
+            if (file.filepath && fs.existsSync(file.filepath)) {
+                fs.unlinkSync(file.filepath);
+            }
         }
         const result = await this.ctx.model.AppCenters.update(
             { logoUrl: [...dirTree, fileName].join('/') },


### PR DESCRIPTION
## 背景
应用中心上传 logo 在部署环境会报错：

`the multipart request can't be consumed twice`

原因是全局 `multipart` 已配置为 `mode: file`，请求进入控制器前文件已经落到临时目录，但 `uploadLogo` 仍然使用 `ctx.getFileStream()` 再次读取请求体，导致 multipart 被二次消费。

<img width="1599" height="351" alt="image" src="https://github.com/user-attachments/assets/734eac11-1c28-4164-84ac-dbbcad5f213e" />


## 改动
- 将 `app/controller/appCenters.js` 的 `uploadLogo` 从 `ctx.getFileStream()` 改为读取 `ctx.request.files`
- 直接复用 Egg 已落盘的临时文件拷贝到目标目录
- 增加缺少上传文件时的参数校验
- 上传完成后主动清理临时文件
- 移除不再使用的 stream 上传相关依赖代码

## 影响范围
- 应用中心 logo 上传接口：`POST /api/appCenters/upload-logo/:id`

## 验证
- 部署环境上传 logo 不再报 `the multipart request can't be consumed twice`
- 本地已验证控制器改动可正常写入目标文件并更新 `logoUrl`

## 风险说明
- 本次仅调整上传文件读取方式，不涉及接口路径、返回结构和资源存储路径变更
- 前端“点击 + 号偶发打开页面”的问题不在本 PR 范围内